### PR TITLE
Update owners.js

### DIFF
--- a/fxos/js/owners.js
+++ b/fxos/js/owners.js
@@ -76,7 +76,7 @@ var OWNERS = {
   "NFC": "Ken Chang (Vincent Chang)", // Firefox OS
   "rtsp": "Ken Chang (Vincent Chang)", // Firefox OS
   "Panning and Zooming": "Milan Sreckovic (Kartikaya Gupta, Botond Ballo)", // Core
-  "Performance": "Mike Lee (Mason Chang)", // Firefox OS
+  "Performance": "Everyone", // Firefox OS
   "Runtime": "Gregor Wagner (Fabrice Desré)", // Firefox OS
   // "Simulator": "?", // Firefox OS
   "RIL": "Ken Chang (Hsinyi Tsai)", // Firefox OS


### PR DESCRIPTION
As of 2014.08.15, the [fxOS Performance Team](https://wiki.mozilla.org/FirefoxOS/Performance) has been dissolved. Performance ownership now moves to all [fxOS Functional & Platform Teams](https://wiki.mozilla.org/FirefoxOS/functionalteams).
