### PR TITLE
Correct many of the mistakes in owners.js

### DIFF
--- a/fxos/js/owners.js
+++ b/fxos/js/owners.js
@@ -5,7 +5,7 @@
 
 var OWNERS = {
   "AudioChannel": "Blake Wu", // Firefox OS
-  "B2g Installer": "Gregor Wagner (Alex Lissy, Dale Harvey)",
+  "B2gInstaller": "Gregor Wagner (Alex Lissy, Dale Harvey)",
   "BetaTriage": "?", // Firefox OS
   "Bluetooth": "Ben Tian", // Firefox OS
   "Build Config": "Dylan Oliver", // Core
@@ -25,47 +25,47 @@ var OWNERS = {
   "DOM: Events": "Andrew Overholt (Johnny Stenback)",
   "Gaia": "David Scravaglieri (Francisco Jordano)",
   // "Gaia:: Achievements": "?",
-  "Gaia::Bluetooth File Transfer": "Tim Guan-tin Chien",
-  "Gaia:: Bookmark": "Gregor Wagner (Ben Francis)",
+  "Gaia::Bluetooth": "Tim Guan-tin Chien",
+  "Gaia::Bookmark": "Gregor Wagner (Ben Francis)",
   "Gaia::Browser": "Gregor Wagner (Ben Francis)",
-  "Gaia:: Bugzilla Lite": "Dale Harvey",
+  "Gaia::Bugzilla Lite": "Dale Harvey",
   "Gaia::Build": "Tim Guan-tin Chien (Ricky Chien)",
   "Gaia::Calendar": "Dylan Oliver (Gareth Aye)",
   "Gaia::Camera": "Hema Koka (David Flanagan)",
   "Gaia::Clock": "Dylan Oliver (Marcus Cavanaugh)",
-  "Gaia:: Components": "Wilson Page",
+  "Gaia::Components": "Wilson Page",
   "Gaia::Contacts": "David Scravaglieri (Francisco Jordano)",
   "Gaia::Cost Control": "David Scravaglieri (Francisco Jordano)",
-  "Gaia:: Customizer": "Doug Sherk",
+  "Gaia::Customizer": "Doug Sherk",
   "Gaia::Dialer": "David Scravaglieri (Francisco Jordano)",
   "Gaia::E-Mail": "Dylan Oliver (Andrew Sutherland)",
   "Gaia::Everything.me": "Gregor Wagner (Chris Lord)",
   // "Gaia:: Feedback": "?",
   "Gaia::First Time Experience": "Gregor Wagner (Sam Foster)",
   "Gaia::FMRadio": "Hema Koka (David Flanagan)",
-  "Gaia:: Foxfooding": "Jean Gong",
+  "Gaia::Foxfooding": "Jean Gong",
   "Gaia::Gallery": "Hema Koka (David Flanagan)",
   "Gaia::GithubBot": "Kevin Grandon",
-  "Gaia:: Hackerplace": "Michael Henretty",
+  "Gaia::Hackerplace": "Michael Henretty",
   "Gaia::Homescreen": "Gregor Wagner (Chris Lord)",
   "Gaia::Keyboard": "Tim Guan-tin Chien",
-  "Gaia:: L10n": "Zibi Braniecki (Stas Malolepszy)",
+  "Gaia::L10n": "Zibi Braniecki (Stas Malolepszy)",
   // "Gaia:: Loop": "?",
   "Gaia::Music": "Hema Koka (David Flanagan)",
-  "Gaia:: Network Alerts": "Steve Chung (Julien Wajsberg, Aleh Zasypkin)",
+  "Gaia::Network Alerts": "Steve Chung (Julien Wajsberg, Aleh Zasypkin)",
   "Gaia::Notes": "Dylan Oliver",
-  // "Gaia:: P2P Sharing": "?",
+  // "Gaia::P2P Sharing": "?",
   // "Gaia::PDF Viewer": "?",
   "Gaia::PerformanceTest": "Eli Perelman (Rob Wood, TingYu Chou)",
-  "Gaia:: Project Infrastructure": "Gareth Aye (Ghislain Locroix, Eli Perelman, Kevin Grandon)",
+  "Gaia::Project Infrastructure": "Gareth Aye (Ghislain Locroix, Eli Perelman, Kevin Grandon)",
   "Gaia::Ringtones": "Hema Koka (David Flanagan)",
   "Gaia::Search": "Gregor Wagner (Kevin Grandon)",
   "Gaia::Settings": "Tim Guan-tin Chien (Fred Lin)",
-  "Gaia:: Shared": "David Flanagan (Kevin Grandon)",
+  "Gaia::Shared": "David Flanagan (Kevin Grandon)",
   "Gaia::SMS": "David Scravaglieri (Francisco Jordano)",
-  "Gaia::System": "Michael Henretty (Gregor Wagner, Tim Guan-tin)", //  Tim relies on Gregor to actively throwing bugs over.
+  "Gaia::System": "Michael Henretty (Gregor Wagner, Tim Guan-tin Chien)", //  Tim to rely on Gregor to actively throwing bugs over.
   "Gaia::System::Accessibility": "Eithan Isaacson, Yura Zenevich",
-  // "Gaia::System::Audio Mgmt": "Alive?",
+  "Gaia::System::Audio Mgmt": "Tim Guan-tin Chien (Evan Tesng)",
   "Gaia::System::Browser Chrome": "Gregor Wagner (Ben Francis)",
   "Gaia::System::Download": "Gregor Wagner (Aus Lacroix)",
   "Gaia::System::Input Mgmt": "Tim Guan-tin Chien",
@@ -76,18 +76,18 @@ var OWNERS = {
   "Gaia::System::Payments": "Fernando Jiménez Moreno",
   // "Gaia::System::Power Mgmt": "?",
   // "Gaia::System::SIM Tool Kit": "?",
-  "Gaia::System::Status Bar, Utility Tray, Notification": "Michael Henretty",
+  "Gaia::System::Status Bar, Utility tray, Notification": "Michael Henretty",
   // "Gaia::System::Storage Mgmt": "?",
   "Gaia::System::System UI": "Michael Henretty",
   "Gaia::System::Task Manager": "Gregor Wagner (Sam Foster)",
-  "Gaia::System::WebRTC": "Fred Lin",
-  "Gaia::System::Wifi": "Tim Guantin Chien",
-  "Gaia::System::Window Mgmt": "Tim Guan-tin Chien (Greg Weng)",
+  "Gaia::System::WebRTC": "Tim Guan-tin Chien (Fred Lin)",
+  "Gaia::System::Wifi": "Tim Guan-tin Chien",
+  "Gaia::System::Window Mgmt": "Tim Guan-tin Chien",
   // "Gaia::TestAgent": "Garreth Aye, Aus Lacroix",
   // "Gaia::Theme Editor": "?",
-  // "Gaia::TV": "?",
-  // "Gaia::TV:: Home": "?",
-  // "Gaia::TV:: System": "?",
+  "Gaia::TV": "Evelyn Hung (Rex Lee)",
+  "Gaia::TV::Home": "Evelyn Hung (Rex Lee)",
+  "Gaia::TV::System": "Evelyn Hung (Rex Lee)",
   "Gaia::UI Tests": "Dylan Oliver (Gareth Aye)",
   "Gaia::Video": "Hema Koka (David Flanagan)",
   "Gaia::VoiceControl": "Dylan Oliver (Kelly Davis)",
@@ -96,7 +96,7 @@ var OWNERS = {
   "General (Firefox OS)": "Mahendranadh Potharaju",
   "General (Core)": "Lawrence Mandel",
   "General (Loop+)": "Lawrence Mandel",
-  "GonkIntegration": "Thomas Tsai", // Firefox OS
+  // "GonkIntegration": "?", // Firefox OS
   "General Automation": "Jonathan Griffin", // Release Engineering
   "Geolocation": "Doug Turner", // Core
   "Graphics": "Milan Sreckovic (Jeff Muizelaar, Benoit Girard)", // Core
@@ -104,23 +104,24 @@ var OWNERS = {
   // "Hardware": "?", // Firefox OS
   "Hardware Abstraction Layer (HAL)": "Dave Hylands", // Core
   "ImageLib": "Milan Sreckovic (Jeff Muizelaar, Seth Fowler)",
-  // "Infrastructure": "?",
+  // "Infrastructure": "?", // Firefox OS
   "IPC": "Andrew Overholt (Johnny Stenback)",
   "JavaScript Engine": "Naveed Ihsanullah", // Core
   "JavaScript: GC": "Naveed Ihsanullah", // Core
   "Layout": "Jet Villegas", // Core
-  // "MCTS Waiver Request": "?",
+  // "MCTS Waiver Request": "?", // Firefox OS
+  // "Metrics": "?", // Firefox OS
   "MTP/UMS": "Ben Tian", // Firefox OS
-  "MFBT": "Naveed Ihsanullah",
+  // "MTBF": "?", // Firefox OS
+  "MFBT": "Naveed Ihsanullah", // Core
   "Networking": "Jason Duell", // Core
   "NFC": "Ethan Tseng", // Firefox OS
-  "rtsp": "Ethan Tseng", // Firefox OS
+  "RTSP": "Ethan Tseng", // Firefox OS
   "Panning and Zooming": "Milan Sreckovic (Kartikaya Gupta, Botond Ballo)", // Core
   "Performance": "Everyone", // Firefox OS
   "Runtime": "Gregor Wagner (Fabrice Desré)", // Firefox OS
   // "Simulator": "?", // Firefox OS
   "RIL": "Hsinyi Tsai", // Firefox OS
-  // "RSTP": "?",
   // "Runtime": "?",
   // "Stimulator": "?",
   // "Stability": "Al Tsai",
@@ -132,6 +133,3 @@ var OWNERS = {
   "Wifi": "Ethan Tseng" // Firefox OS
   // "WMF": "?" // Firefox OS
 };
-
-
-


### PR DESCRIPTION
Unfortunately there are too much changes so GitHub refused to show line-by-line diff. Summarizing the change below:

* Go through [FxOS components](https://bugzilla.mozilla.org/describecomponents.cgi?product=Firefox%20OS) and ensure all comp are listed, even listed with a "?" and commented out.
* Add Evelyn Hung for Gaia TV comps.
* Remove Thomas Tsai -- he left as a long time ago.
* Normalize listing to ensure it can exactly matches Bugzilla query result (are we still matching the comp name exactly? Looks like we don't do that anymore but unassigned comp now shows ugly lower caps on the chart)

I tend to think we should short this list by Product first than component... Andreas created this chart long time ago only to track FxOS product and it doesn't do just that anymore. We should fix it altogether and make sure no components are left out.