### PR TITLE
Adjust for not having aurora any longer, and also don't count tracking for old releases as tracking nightly

### DIFF
--- a/platform/js/util.js
+++ b/platform/js/util.js
@@ -354,8 +354,7 @@ function setReleaseHTML(data){
 
 	var scale = aMath.min(30, MAX_VERTICAL_HEIGHT / aMath.MAX(data.cube[1]), MAX_VERTICAL_HEIGHT / aMath.MAX(data.cube[2]));
 	var BETA = data.edges[0].domain.partitions[1];
-	var AURORA = data.edges[0].domain.partitions[2];
-	var ESR = data.edges[0].domain.partitions[3];
+	var NIGHTLY = data.edges[0].domain.partitions[2];
 
 	var beta = data.edges[1].domain.partitions.map(function(p, i){
 		var style = {
@@ -392,47 +391,15 @@ function setReleaseHTML(data){
 			"vertical-align": "bottom",
 			"text-align": "center",
 			"display": "inline-block",
-			"background-color": AURORA.style.color
+			"background-color": NIGHTLY.style.color
 		};
 		return devTemplate.replace({
 			"id": "tracking_2_" + i,
 			"value": data.cube[2][i],
 			"style": style,
-			"lighter": Color.newInstance(AURORA.style.color).lighter()
+			"lighter": Color.newInstance(NIGHTLY.style.color).lighter()
 		});
 	}).join("");
-
-
-	var esrTemplate = new Template([
-		'<td style="vertical-align:middle;text-align: center; width:'+WIDTH+'px;">',
-		'<div id="{{id}}" class="hoverable tracking" style="{{style|style}}" dynamic-style=":hover{background-color:{{lighter}}}">',
-		'<div style="padding-top:6px;">{{value}}</div>',
-		'</div>',
-		'</td>'
-	]);
-	var esr = data.edges[1].domain.partitions.map(function(p, i){
-		var style = {
-			"width": BAR_WIDTH+"px",
-			"height": BAR_WIDTH+"px",
-			"color": "white",
-			"vertical-align": "middle",
-			"text-align": "center",
-			"display": "inline-block",
-			"background-color": ESR.style.color
-		};
-		if (data.cube[3][i] > 0) {
-			return esrTemplate.replace({
-				"id": "tracking_3_" + i,
-				"value": data.cube[3][i],
-				"style": style,
-				"lighter": Color.newInstance(ESR.style.color).lighter()
-			});
-		} else {
-			return "<td></td>";
-		}//endif
-
-	}).join("");
-
 
 	$("#teams").html(
 			'<div></div>' +
@@ -447,7 +414,7 @@ function setReleaseHTML(data){
 			'</table>'
 	);
 	$("#beta_title").html('<h3 style="position:absolute;display:block;bottom:40px;right:0;">Beta&nbsp;(' + BETA.version + ')</h3>');
-	$("#aurora_title").html('<h3 style="position:absolute;display:block;top:40px;right:0;">Aurora&nbsp;(' + AURORA.version + ')</h3>');
+	$("#nightly_title").html('<h3 style="position:absolute;display:block;top:40px;right:0;">Nightly&nbsp;(' + NIGHTLY.version + ')</h3>');
 
 	//ADD CLICKERS
 	$(".tracking").click(function(){

--- a/platform/modevlib/Dimension-Platform.js
+++ b/platform/modevlib/Dimension-Platform.js
@@ -278,7 +278,6 @@ if (!Mozilla) var Mozilla = {"name": "Mozilla", "edges": []};
 	var trains = [
 		{"name": "Release", "columnName": "release", "style": {"color": "#E66000"}},
 		{"name": "Beta", "columnName": "beta", "style": {"color": "#FF9500"}},
-		{"name": "Aurora", "columnName": "aurora", "style": {"color": "#0095DD"}},
 		{"name": "Nightly", "columnName": "nightly", "style": {"color": "#002147"}}
 	];
 
@@ -287,18 +286,11 @@ if (!Mozilla) var Mozilla = {"name": "Mozilla", "edges": []};
 		"name": "Release Tracking - Desktop",
 		"esFacet": true,
 		"requiredFields": releaseTracking.requiredFields,
-		"edges": trains.leftBut(1).map(function(t, track){
+		"edges": trains.map(function(t, track){
 			var release = releaseTracking.edges[currentRelease.dataIndex + track];
 			return Map.setDefault({}, t, release);
 		})
 	};
-	trainTrackingAbs.edges.append({
-		"name": trains.last().name,
-		"columnName": "nightly",
-		"version": trains.last().version,
-		"style": trains.last().style,
-		"esfilter": otherFilter
-	});
 
 	//SHOW TRAINS AS PARTIITONS SO THERE IS NO DOUBLE COUNTING
 	var trainTrackingRel = {
@@ -306,17 +298,12 @@ if (!Mozilla) var Mozilla = {"name": "Mozilla", "edges": []};
 		"columnName": "train",
 		"isFacet": true,
 		"requiredFields": releaseTracking.requiredFields,
-		"partitions": trains.leftBut(1).map(function(t, track){
+		"partitions": trains.map(function(t, track){
 			var release = releaseTracking.edges[currentRelease.dataIndex + track];
 			var output = Map.setDefault({}, t, release);
 			return output;
 		})
 	};
-	trainTrackingRel.partitions.append({
-		"name": trains.last().name,
-		"style": trains.last().style,
-		"esfilter": otherFilter
-	});
 	trainTrackingRel.partitions.append({
 		"name": "ESR-31",
 		"style": trains.last().style,

--- a/platform/releases.html
+++ b/platform/releases.html
@@ -27,7 +27,7 @@
 				</tr>
 				<tr>
 					<td>
-						<div id="aurora_title" class="train_title" style="position:relative;" layout="right=title[0,1].right"></div>
+						<div id="nightly_title" class="train_title" style="position:relative;" layout="right=title[0,1].right"></div>
 
 					</td>
 				</tr>


### PR DESCRIPTION
These were the fixes I needed to make releases.html do the right thing for Nightly (in particular, the numbers were right, but the label was wrong).

I think this is an improvement to dashboard.html as well, since it's no longer ticking the "nightly" column for things that are tracking+ for old releases.  It's actually a more substantive change there, since it removes the "Aurora" column, and corrects the "Nightly" column to actually be about nightly rather than being about nightly or anything else.  (Or maybe that was intentional for some reason, but it's confusing!)

I suspect release-history.html may not be entirely right, though.

Again, this was against the platform branch rather than dev because that seemed the most current.